### PR TITLE
Fixed incorrect link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,19 @@
 # GitHub Security Policy
 
-Software security researchers are increasingly engaging with Internet companies to hunt down vulnerabilities. Our bounty program gives a tip of the hat to these researchers and provides rewards of $30,000 or more for critical vulnerabilities.
+Software security researchers are increasingly engaging with Internet 
+companies to hunt down vulnerabilities. Our bounty program gives a tip of the 
+hat to these researchers and provides rewards of $30,000 or more for critical 
+vulnerabilities.
 
-If you’ve found a vulnerability, [submit it here](https://hackerone.com/github).
+If you’ve found a vulnerability, [submit it here][hackerone].
 
-You can find useful information in our [rules](https://bounty.github.com/#rules), [scope](https://bounty.github.com/#scope), [targets](https://bounty.github.com/#scope) and [FAQ](https://bounty.github.com/#faqs).
+You can find useful information in our [rules][gh-rules],
+[scope][gh-scope], [targets][gh-target] and [FAQ][gh-faq].
+
+[//]: # (Links to references above.)
+
+[hackerone]: https://hackerone.com/github
+[gh-rules]: https://bounty.github.com/#rules
+[gh-scope]: https://bounty.github.com/#scope
+[gh-target]: https://bounty.github.com/#targets
+[gh-faq]: https://bounty.github.com/#faqs


### PR DESCRIPTION
- Fixed link to targets from `#scope` to `#targets`.
- Cleaned up formatting and links in the document.