### PR TITLE
specify .github directory for codeowners

### DIFF
--- a/config/repolinter-ruleset.json
+++ b/config/repolinter-ruleset.json
@@ -49,7 +49,7 @@
             "rule": {
                 "type": "file-existence",
                 "options": {
-                    "globsAny": ["CODEOWNERS*", "*/CODEOWNERS*"],
+                    "globsAny": ["CODEOWNERS*", ".github/CODEOWNERS*"],
                     "nocase": true
                 }
             },


### PR DESCRIPTION
i don't think that the previous `*/CODEOWNERS*` pattern was matching the .github directory correctly.