### PR TITLE
Allow CODEOWNERS file detection to see into the .github directory

### DIFF
--- a/config/repolinter-ruleset.json
+++ b/config/repolinter-ruleset.json
@@ -49,7 +49,7 @@
             "rule": {
                 "type": "file-existence",
                 "options": {
-                    "globsAny": ["CODEOWNERS*", "*/CODEOWNERS*"],
+                    "globsAny": ["CODEOWNERS*", "*/CODEOWNERS*", ".github/CODEOWNERS*"],
                     "nocase": true
                 }
             },


### PR DESCRIPTION
`*/CODEOWNERS` was not matching directories beginning with . such as `.github/CODEOWNERS`.

This should solve the issue we saw in [this run](https://github.com/github/open-source-releases/issues/247#issuecomment-1115180957) where `CODEOWNERS` was present but not detected.