### PR TITLE
Capitalize the word git

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,7 +20,7 @@ We contribute to the tools 🔧 we rely on to build and run GitHub, while also m
 
 - [GitHub CLI](https://github.com/cli/cli) - A command line tool for GitHub
 - [GitHub Desktop](https://github.com/desktop/desktop) - A visual approach to using Git with GitHub
-- [Git Large File Storage](https://github.com/git-lfs/git-lfs) - A git extension for versioning large files
+- [Git Large File Storage](https://github.com/git-lfs/git-lfs) - A Git extension for versioning large files
 - [Primer](https://github.com/primer/css) - The GitHub design system
 
 ### 👓 Appendix


### PR DESCRIPTION
Minor fix in profile/README.md where the word "git" should be capitalized to "Git" in the sentence, "A git extension for versioning large files."